### PR TITLE
 feat: use isbn13 if isbn isn't available

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"dev": "micro-dev"
 	},
 	"files": [
-		"index.js"
+    "index.js",
+    "transform-book.js"
 	],
 	"keywords": [
 		"api",


### PR DESCRIPTION
This PR fixes the `readAt` check ensuring only books that _have been_ read are shown. It also uses the isbn13 when an isbn isn't available.