### PR TITLE
feat: target the read shelf in the Goodreads call

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const GOOGLE_API = `https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}&ke
 
 async function fetchLatest() {
   try {
-    const {body} = await got(`https://www.goodreads.com/review/list/${GOODREADS_LIST_ID}.xml?key=${GOODREADS_API_KEY}&v=2`);
+    const {body} = await got(`https://www.goodreads.com/review/list/${GOODREADS_LIST_ID}.xml?key=${GOODREADS_API_KEY}&v=2&shelf=read`);
 
     const reviews = await new Promise((resolve, reject) => {
       parseString(body, (error, result) => {


### PR DESCRIPTION
Yesterday I added a ton of books to my Goodreads list and discovered that it broke the recently read section of my website. The reason was because I only request the first page of data from Goodreads and then filter out books without a `read_at` value.

The two ways I'd prefer to handle this situation are:

1. Request a specific shelf, which the Goodreads [API endpoint I'm using supports](https://www.goodreads.com/api/index#reviews.list).
2. Fetch all pages from the endpoint.

This PR implements the first.