### PR TITLE
refactor: move http => https function to an external package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9077,9 +9077,9 @@
 			"dev": true
 		},
 		"to-https": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/to-https/-/to-https-1.0.1.tgz",
-			"integrity": "sha512-Mtmv7Ipy+XvkzmyOhPFfqUC8zmDA4nQb6noqCr4oASMzgTVk7vDKe0VtI8n4YQGTJk/pXiydR9qwC3kkxw1itg=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/to-https/-/to-https-1.0.2.tgz",
+			"integrity": "sha512-aUhHs5Aq8kjrLGMgN6gV/8YlTBXlr20StoKYfnbcMyzO3b/K52gwICCw8i320rYqQWJ/A/J2TV8pneax7NVSDw=="
 		},
 		"to-object-path": {
 			"version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "recently-read",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9075,6 +9075,11 @@
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
 			"dev": true
+		},
+		"to-https": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/to-https/-/to-https-1.0.1.tgz",
+			"integrity": "sha512-Mtmv7Ipy+XvkzmyOhPFfqUC8zmDA4nQb6noqCr4oASMzgTVk7vDKe0VtI8n4YQGTJk/pXiydR9qwC3kkxw1itg=="
 		},
 		"to-object-path": {
 			"version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -19,23 +19,24 @@
 		"dev": "micro-dev"
 	},
 	"files": [
-    "index.js",
-    "transform-book.js"
+		"index.js",
+		"transform-book.js"
 	],
 	"keywords": [
 		"api",
-    "books",
-    "goodreads",
-    "google-books",
-    "microservice",
-    "read",
-    "read-list",
-    "reading"
+		"books",
+		"goodreads",
+		"google-books",
+		"microservice",
+		"read",
+		"read-list",
+		"reading"
 	],
 	"dependencies": {
 		"control-access": "^0.1.1",
 		"etag": "^1.8.1",
 		"micro": "^9.3.3",
+		"to-https": "^1.0.1",
 		"xml2js": "^0.4.19"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"control-access": "^0.1.1",
 		"etag": "^1.8.1",
 		"micro": "^9.3.3",
-		"to-https": "^1.0.1",
+		"to-https": "^1.0.2",
 		"xml2js": "^0.4.19"
 	},
 	"devDependencies": {

--- a/transform-book.js
+++ b/transform-book.js
@@ -1,4 +1,4 @@
-const convertToHttps = url => url.replace(/(^http:\/\/)|(^\/\/)/, 'https://');
+const convertToHttps = require('to-https');
 
 module.exports = result => {
   const {body} = result;


### PR DESCRIPTION
This PR moves the http => https transformation code into a dedicated package that can be maintained separately and reused in my other projects. It is available on npm as [`to-https`](https://www.npmjs.com/package/to-https).

### Screenshot

_Response is unchanged._

<img width="1065" alt="screen shot 2019-01-19 at 10 13 16 am" src="https://user-images.githubusercontent.com/1934719/51430616-f3455480-1bd2-11e9-8275-8f77afc980b1.png">
