### PR TITLE
refactor: break apart to individual modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const GOOGLE_API = `https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}&ke
 async function getRecentlyReadBooks() {
   try {
     const reviews = await fetchReviews(GOODREADS_API_KEY, GOODREADS_LIST_ID);
-    const isbns = reviews.reduce(reviewToIsbn);
+    const isbns = reviews.reduce(reviewToIsbn, []);
 
     const bookPromises = isbns.map(isbn => got(GOOGLE_API.replace('{isbn}', isbn)));
     const bookResults = await Promise.all(bookPromises);
@@ -52,7 +52,7 @@ async function getRecentlyReadBooks() {
     responseText = JSON.stringify(books);
     responseETag = etag(responseText);
   } catch (error) {
-    console.log('Error fetching reviews data.', error);
+    console.log(error);
   }
 }
 

--- a/lib/fetch-book.js
+++ b/lib/fetch-book.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const got = require('got');
+
+module.exports = async (apiKey, book) => {
+  const {isbn, rating} = book;
+
+  const GOOGLE_API = `https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}&key=${apiKey}`;
+
+  try {
+    const response = await got(GOOGLE_API.replace('{isbn}', book.isbn));
+    const {body} = response;
+    const {items: [bookData] = []} = JSON.parse(body);
+
+    if (!bookData) {
+      throw new Error(`Failed to fetch Google Books data for ${isbn}.`);
+    }
+
+    return {
+      book: bookData,
+      rating
+    };
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/lib/fetch-book.js
+++ b/lib/fetch-book.js
@@ -8,8 +8,8 @@ module.exports = async (apiKey, book) => {
   const GOOGLE_API = `https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}&key=${apiKey}`;
 
   try {
-    const response = await got(GOOGLE_API.replace('{isbn}', book.isbn));
-    const {body} = response;
+    const {body} = await got(GOOGLE_API.replace('{isbn}', book.isbn));
+    // const {body} = response;
     const {items: [bookData] = []} = JSON.parse(body);
 
     if (!bookData) {

--- a/lib/fetch-book.js
+++ b/lib/fetch-book.js
@@ -9,7 +9,6 @@ module.exports = async (apiKey, book) => {
 
   try {
     const {body} = await got(GOOGLE_API.replace('{isbn}', book.isbn));
-    // const {body} = response;
     const {items: [bookData] = []} = JSON.parse(body);
 
     if (!bookData) {

--- a/lib/fetch-reviews.js
+++ b/lib/fetch-reviews.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const got = require('got');
+const {parseString} = require('xml2js');
+
+module.exports = async (apiKey, listId) => {
+  const {body} = await got(`https://www.goodreads.com/review/list/${listId}.xml?key=${apiKey}&v=2&shelf=read&sort=date_read`);
+
+  await new Promise((resolve, reject) => {
+    parseString(body, (error, result) => {
+      if (error) {
+        reject(error);
+      }
+
+      const reviews = result.GoodreadsResponse.reviews[0].review;
+      resolve(reviews);
+    });
+  });
+}

--- a/lib/fetch-reviews.js
+++ b/lib/fetch-reviews.js
@@ -6,7 +6,7 @@ const {parseString} = require('xml2js');
 module.exports = async (apiKey, listId) => {
   const {body} = await got(`https://www.goodreads.com/review/list/${listId}.xml?key=${apiKey}&v=2&shelf=read&sort=date_read`);
 
-  await new Promise((resolve, reject) => {
+  const reviews = await new Promise((resolve, reject) => {
     parseString(body, (error, result) => {
       if (error) {
         reject(error);
@@ -16,4 +16,6 @@ module.exports = async (apiKey, listId) => {
       resolve(reviews);
     });
   });
-}
+
+  return reviews;
+};

--- a/lib/fetch-reviews.test.js
+++ b/lib/fetch-reviews.test.js
@@ -1,0 +1,45 @@
+const {expect} = require('chai');
+const proxyquire = require('proxyquire');
+const {stub} = require('sinon');
+
+const apiKey = 'fake-api-key';
+const listId = 'fake-list-id';
+const mockId = '2619225074';
+const validResponse = {
+  body: `
+<GoodreadsResponse>
+  <reviews>
+    <review>
+      <id>${mockId}</id>
+    </review>
+  </reviews>
+</GoodreadsResponse>`
+};
+
+describe('fetch-reviews', () => {
+  let fetchReviews;
+  const stubGot = stub();
+
+  before(() => {
+    fetchReviews = proxyquire('./fetch-reviews', {
+      got: stubGot
+    });
+  });
+
+  beforeEach(() => {
+    stubGot.resetHistory();
+    stubGot.resolves(validResponse);
+  });
+
+  it('calls the Google Books API with the expected params', async () => {
+    await fetchReviews(apiKey, listId);
+    expect(stubGot.args).to.deep.equal([[
+      `https://www.goodreads.com/review/list/${listId}.xml?key=${apiKey}&v=2&shelf=read&sort=date_read`
+    ]]);
+  });
+
+  it('parses and returns the JSON review data', async () => {
+    const reviews = await fetchReviews(apiKey, listId);
+    expect(reviews).to.deep.equal([{id: [mockId]}]);
+  });
+});

--- a/lib/review-to-isbn.js
+++ b/lib/review-to-isbn.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const isString = subject => typeof subject === 'string';
+
+module.exports = (acc, book) => {
+  const {read_at: readAt} = book;
+  const [date] = readAt;
+
+  if (!isString(date) && date.length > 3) {
+    return;
+  }
+
+  const [{isbn: isbnArr = [], isbn13: isbn13Arr = []}] = book;
+  const [isbn10] = isbnArr;
+  const [isbn13] = isbn13Arr;
+
+  const isbn = isString(isbn10) ? isbn10 : isString(isbn13) ? isbn13 : false;
+  if (Array.isArray(acc) && isString(isbn)) {
+    acc.push(isbn);
+  }
+
+  return acc;
+};

--- a/lib/review-to-isbn.js
+++ b/lib/review-to-isbn.js
@@ -3,14 +3,14 @@
 const isString = subject => typeof subject === 'string';
 
 module.exports = (acc, book) => {
-  const {read_at: readAt} = book;
-  const [date] = readAt;
+  const {read_at: [date]} = book;
 
   if (!isString(date) && date.length > 3) {
     return;
   }
 
-  const [{isbn: isbnArr = [], isbn13: isbn13Arr = []}] = book;
+  const {book: bookData} = book.test.ano;
+  const [{isbn: isbnArr = [], isbn13: isbn13Arr = []}] = bookData;
   const [isbn10] = isbnArr;
   const [isbn13] = isbn13Arr;
 

--- a/lib/transform-book.js
+++ b/lib/transform-book.js
@@ -4,7 +4,7 @@ const convertToHttps = require('to-https');
 
 module.exports = result => {
   const {body} = result;
-  const {items} = JSON.parse(body);
+  const {items = []} = JSON.parse(body);
 
   if (!items) {
     return;

--- a/lib/transform-book.js
+++ b/lib/transform-book.js
@@ -1,10 +1,12 @@
+'use strict';
+
 const convertToHttps = require('to-https');
 
 module.exports = result => {
   const {body} = result;
-  const {items = []} = JSON.parse(body);
+  const {items} = JSON.parse(body);
 
-  if (!items.length > 0) {
+  if (!items) {
     return;
   }
 

--- a/lib/transform-book.js
+++ b/lib/transform-book.js
@@ -2,32 +2,35 @@
 
 const convertToHttps = require('to-https');
 
-module.exports = result => {
-  const {body} = result;
-  const {items = []} = JSON.parse(body);
-
-  if (!items) {
-    return;
-  }
-
+module.exports = book => {
   const {
-    volumeInfo: {
-      authors,
-      imageLinks: {
-        smallThumbnail,
-        thumbnail
-      } = {},
-      infoLink,
-      pageCount,
-      title
-    } = {}
-  } = items.length && items[0];
+    book: {
+      volumeInfo: {
+        authors,
+        categories = [],
+        imageLinks: {
+          smallThumbnail,
+          thumbnail
+        } = {},
+        infoLink,
+        pageCount,
+        previewLink,
+        subtitle,
+        title
+      } = {}
+    } = {},
+    rating
+  } = book;
 
   return {
     authors,
+    categories,
     infoLink: convertToHttps(infoLink),
     pageCount,
+    previewLink,
+    rating,
     smallThumbnail: convertToHttps(smallThumbnail),
+    subtitle,
     thumbnail: convertToHttps(thumbnail),
     title
   };

--- a/lib/transform-review.js
+++ b/lib/transform-review.js
@@ -9,14 +9,17 @@ module.exports = (acc, book) => {
     return;
   }
 
-  const {book: bookData} = book.test.ano;
+  const {book: bookData, rating: [rating]} = book;
   const [{isbn: isbnArr = [], isbn13: isbn13Arr = []}] = bookData;
   const [isbn10] = isbnArr;
   const [isbn13] = isbn13Arr;
 
-  const isbn = isString(isbn10) ? isbn10 : isString(isbn13) ? isbn13 : false;
+  const isbn = isString(isbn13) ? isbn13 : isString(isbn10) ? isbn10 : false;
   if (Array.isArray(acc) && isString(isbn)) {
-    acc.push(isbn);
+    acc.push({
+      isbn,
+      rating
+    });
   }
 
   return acc;

--- a/package-lock.json
+++ b/package-lock.json
@@ -398,6 +398,58 @@
 				"arrify": "^1.0.1"
 			}
 		},
+		"@jest/console": {
+			"version": "24.7.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+			"dev": true,
+			"requires": {
+				"@jest/source-map": "^24.3.0",
+				"chalk": "^2.0.1",
+				"slash": "^2.0.0"
+			}
+		},
+		"@jest/source-map": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"dev": true,
+			"requires": {
+				"callsites": "^3.0.0",
+				"graceful-fs": "^4.1.15",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"@jest/test-result": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+			"dev": true,
+			"requires": {
+				"@jest/console": "^24.7.1",
+				"@jest/types": "^24.8.0",
+				"@types/istanbul-lib-coverage": "^2.0.0"
+			}
+		},
+		"@jest/types": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^1.1.1",
+				"@types/yargs": "^12.0.9"
+			}
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -422,6 +474,38 @@
 			"requires": {
 				"symbol-observable": "^1.2.0"
 			}
+		},
+		"@sinonjs/commons": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+			"integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/formatio": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+			"integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+			"requires": {
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^3.1.0"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+			"integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+			"requires": {
+				"@sinonjs/commons": "^1.0.2",
+				"array-from": "^2.1.1",
+				"lodash": "^4.17.11"
+			}
+		},
+		"@sinonjs/text-encoding": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
 		},
 		"@szmarczak/http-timer": {
 			"version": "1.1.1",
@@ -449,6 +533,31 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+			"dev": true
+		},
+		"@types/istanbul-lib-report": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+			"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+			"dev": true,
+			"requires": {
+				"@types/istanbul-lib-coverage": "*",
+				"@types/istanbul-lib-report": "*"
+			}
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -459,6 +568,18 @@
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.0.tgz",
 			"integrity": "sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==",
+			"dev": true
+		},
+		"@types/stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+			"dev": true
+		},
+		"@types/yargs": {
+			"version": "12.0.12",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
 			"dev": true
 		},
 		"acorn": {
@@ -493,6 +614,12 @@
 			"requires": {
 				"string-width": "^2.0.0"
 			}
+		},
+		"ansi-colors": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+			"dev": true
 		},
 		"ansi-escapes": {
 			"version": "3.2.0",
@@ -594,6 +721,11 @@
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
 			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
 			"dev": true
+		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
 		},
 		"array-includes": {
 			"version": "3.0.3",
@@ -1065,6 +1197,12 @@
 					}
 				}
 			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
 		},
 		"buf-compare": {
 			"version": "1.0.1",
@@ -2515,6 +2653,17 @@
 			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 			"dev": true
 		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+		},
+		"diff-sequences": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"dev": true
+		},
 		"dir-glob": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
@@ -3349,6 +3498,20 @@
 				}
 			}
 		},
+		"expect": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+			"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.8.0",
+				"ansi-styles": "^3.2.0",
+				"jest-get-type": "^24.8.0",
+				"jest-matcher-utils": "^24.8.0",
+				"jest-message-util": "^24.8.0",
+				"jest-regex-util": "^24.3.0"
+			}
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3531,6 +3694,15 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
+		"fill-keys": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+			"requires": {
+				"is-object": "~1.0.1",
+				"merge-descriptors": "~1.0.0"
+			}
+		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -3572,6 +3744,23 @@
 			"dev": true,
 			"requires": {
 				"locate-path": "^2.0.0"
+			}
+		},
+		"flat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+			"dev": true,
+			"requires": {
+				"is-buffer": "~2.0.3"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+					"dev": true
+				}
 			}
 		},
 		"flat-cache": {
@@ -4397,6 +4586,12 @@
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 			"dev": true
 		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
 		"handlebars": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
@@ -4527,6 +4722,12 @@
 			"requires": {
 				"is-stream": "^1.0.1"
 			}
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
 		},
 		"hosted-git-info": {
 			"version": "2.7.1",
@@ -4958,6 +5159,11 @@
 				"obj-props": "^1.0.0"
 			}
 		},
+		"is-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+		},
 		"is-observable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
@@ -5209,6 +5415,58 @@
 				"handlebars": "^4.1.2"
 			}
 		},
+		"jest-diff": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+			"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"diff-sequences": "^24.3.0",
+				"jest-get-type": "^24.8.0",
+				"pretty-format": "^24.8.0"
+			}
+		},
+		"jest-get-type": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+			"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+			"dev": true
+		},
+		"jest-matcher-utils": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+			"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"jest-diff": "^24.8.0",
+				"jest-get-type": "^24.8.0",
+				"pretty-format": "^24.8.0"
+			}
+		},
+		"jest-message-util": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+			"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@jest/test-result": "^24.8.0",
+				"@jest/types": "^24.8.0",
+				"@types/stack-utils": "^1.0.1",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^2.0.0",
+				"stack-utils": "^1.0.1"
+			}
+		},
+		"jest-regex-util": {
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"dev": true
+		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -5325,6 +5583,11 @@
 				"verror": "1.10.0"
 			}
 		},
+		"just-extend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
+		},
 		"keyv": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -5410,8 +5673,7 @@
 		"lodash": {
 			"version": "4.17.11",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-			"dev": true
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
@@ -5523,6 +5785,11 @@
 			"requires": {
 				"chalk": "^2.0.1"
 			}
+		},
+		"lolex": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.0.1.tgz",
+			"integrity": "sha512-UHuOBZ5jjsKuzbB/gRNNW8Vg8f00Emgskdq2kvZxgBJCS0aqquAuXai/SkWORlKeZEiNQWZjFZOqIUcH9LqKCw=="
 		},
 		"loud-rejection": {
 			"version": "1.6.0",
@@ -5650,6 +5917,11 @@
 					}
 				}
 			}
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
 		},
 		"merge-source-map": {
 			"version": "1.1.0",
@@ -6186,6 +6458,278 @@
 				"minimist": "0.0.8"
 			}
 		},
+		"mocha": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
+			"integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "3.2.3",
+				"browser-stdout": "1.3.1",
+				"debug": "3.2.6",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"find-up": "3.0.0",
+				"glob": "7.1.3",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.13.1",
+				"log-symbols": "2.2.0",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"ms": "2.1.1",
+				"node-environment-flags": "1.0.5",
+				"object.assign": "4.1.0",
+				"strip-json-comments": "2.0.1",
+				"supports-color": "6.0.0",
+				"which": "1.3.1",
+				"wide-align": "1.1.3",
+				"yargs": "13.2.2",
+				"yargs-parser": "13.0.0",
+				"yargs-unparser": "1.5.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"dev": true
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"mem": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^2.0.0",
+						"p-is-promise": "^2.0.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"os-locale": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+					"dev": true,
+					"requires": {
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+					"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.2.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+					"integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"os-locale": "^3.1.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+					"integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"module-not-found-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+			"integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
+		},
 		"mri": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.1.tgz",
@@ -6286,6 +6830,25 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
+		"nise": {
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+			"integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+			"requires": {
+				"@sinonjs/formatio": "^3.1.0",
+				"@sinonjs/text-encoding": "^0.7.1",
+				"just-extend": "^4.0.2",
+				"lolex": "^2.3.2",
+				"path-to-regexp": "^1.7.0"
+			},
+			"dependencies": {
+				"lolex": {
+					"version": "2.7.5",
+					"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
+				}
+			}
+		},
 		"nock": {
 			"version": "10.0.2",
 			"resolved": "https://registry.npmjs.org/nock/-/nock-10.0.2.tgz",
@@ -6311,6 +6874,24 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				}
+			}
+		},
+		"node-environment-flags": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+			"integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+			"dev": true,
+			"requires": {
+				"object.getownpropertydescriptors": "^2.0.3",
+				"semver": "^5.7.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -6681,6 +7262,28 @@
 				}
 			}
 		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
 		"object.pick": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -7019,8 +7622,22 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"requires": {
+				"isarray": "0.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				}
+			}
 		},
 		"path-type": {
 			"version": "3.0.0",
@@ -7255,6 +7872,26 @@
 				"utila": "~0.4"
 			}
 		},
+		"pretty-format": {
+			"version": "24.8.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+			"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "^24.8.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				}
+			}
+		},
 		"pretty-ms": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-4.0.0.tgz",
@@ -7287,6 +7924,26 @@
 			"resolved": "https://registry.npmjs.org/proto-props/-/proto-props-2.0.0.tgz",
 			"integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
 			"dev": true
+		},
+		"proxyquire": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+			"integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+			"requires": {
+				"fill-keys": "^1.0.2",
+				"module-not-found-error": "^1.0.0",
+				"resolve": "~1.8.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+					"requires": {
+						"path-parse": "^1.0.5"
+					}
+				}
+			}
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -7358,6 +8015,12 @@
 					"dev": true
 				}
 			}
+		},
+		"react-is": {
+			"version": "16.8.6",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+			"dev": true
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -8074,6 +8737,20 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true
+		},
+		"sinon": {
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+			"integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+			"requires": {
+				"@sinonjs/commons": "^1.4.0",
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/samsam": "^3.3.1",
+				"diff": "^3.5.0",
+				"lolex": "^4.0.1",
+				"nise": "^1.4.10",
+				"supports-color": "^5.5.0"
+			}
 		},
 		"slash": {
 			"version": "2.0.0",
@@ -8835,8 +9512,7 @@
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"dev": true
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
 		},
 		"type-fest": {
 			"version": "0.3.1",
@@ -9172,6 +9848,15 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
 		"widest-line": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
@@ -9486,6 +10171,178 @@
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 					"dev": true
+				}
+			}
+		},
+		"yargs-unparser": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+			"integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+			"dev": true,
+			"requires": {
+				"flat": "^4.1.0",
+				"lodash": "^4.17.11",
+				"yargs": "^12.0.5"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"dev": true
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"mem": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^2.0.0",
+						"p-is-promise": "^2.0.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				},
+				"os-locale": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+					"dev": true,
+					"requires": {
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "12.0.5",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^4.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^3.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1 || ^4.0.0",
+						"yargs-parser": "^11.1.1"
+					}
+				},
+				"yargs-parser": {
+					"version": "11.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				}
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "recently-read",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "book-list-microservice",
+	"name": "recently-read",
 	"version": "1.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -8020,12 +8020,6 @@
 				"semver": "^5.0.3"
 			}
 		},
-		"serialize-error": {
-			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-			"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
-			"dev": true
-		},
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -8477,6 +8471,14 @@
 				"js-yaml": "^3.10.0",
 				"serialize-error": "^2.1.0",
 				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"serialize-error": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+					"integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
+					"dev": true
+				}
 			}
 		},
 		"supports-color": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 	},
 	"scripts": {
 		"dev": "micro-dev",
-    "start": "micro --listen tcp://127.0.0.1:3001",
-    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
+		"start": "micro --listen tcp://127.0.0.1:3001",
+		"report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
 		"test": "xo && nyc ava"
 	},
 	"files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "recently-read",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "A Goodreads-powered book list microservice",
 	"license": "MIT",
 	"private": true,
@@ -18,7 +18,7 @@
 		"dev": "micro-dev",
 		"lint": "xo --env=node --env=mocha",
 		"start": "micro --listen tcp://127.0.0.1:3001",
-		"test": "npm run lint && unit",
+		"test": "npm run lint && npm run unit",
 		"report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
 		"unit": "mocha ./**/*.test.js"
 	},

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
 		"node": ">=8"
 	},
 	"scripts": {
+		"coverage": "nyc npm run unit",
 		"dev": "micro-dev",
+		"lint": "xo --env=node --env=mocha",
 		"start": "micro --listen tcp://127.0.0.1:3001",
+		"test": "npm run lint && unit",
 		"report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
-		"test": "xo && nyc ava"
+		"unit": "mocha ./**/*.test.js"
 	},
 	"files": [
 		"index.js",
@@ -38,15 +41,20 @@
 		"control-access": "^0.1.1",
 		"etag": "^1.8.1",
 		"micro": "^9.3.3",
+		"proxyquire": "^2.1.0",
+		"sinon": "^7.3.2",
 		"to-https": "^1.0.2",
 		"xml2js": "^0.4.19"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",
+		"chai": "^4.2.0",
 		"codecov": "^3.0.0",
 		"delay": "^4.1.0",
+		"expect": "^24.8.0",
 		"got": "^9.3.1",
 		"micro-dev": "^3.0.0",
+		"mocha": "^6.1.4",
 		"nock": "^10.0.1",
 		"nyc": "^14.1.0",
 		"test-listen": "^1.1.0",


### PR DESCRIPTION
This PR breaks down the code into separate modules and also starts to add unit tests using mocha and chai. It also return new `ratings`, `subtitle`, `categories`, and `subtitle` properties when available for a book.

### Example response object

```js
[
  {
    authors: ["Kate Moore"],
    categories: ["Health & Fitness"],
    infoLink: "https://books.google.com/books?id=tT8AvgAACAAJ&dq=isbn:9781492649359&hl=&source=gbs_api",
    pageCount: 480,
    previewLink: "http://books.google.com/books?id=tT8AvgAACAAJ&dq=isbn:9781492649359&hl=&cd=1&source=gbs_api",
    rating: "5",
    smallThumbnail: "https://books.google.com/books/content?id=tT8AvgAACAAJ&printsec=frontcover&img=1&zoom=5&source=gbs_api",
    subtitle: "The Dark Story of America's Shining Women",
    thumbnail: "https://books.google.com/books/content?id=tT8AvgAACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api",
    title: "The Radium Girls"
  },
]